### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@
 
 2.安能饭否源码中 **不包含** oauth key信息，因此直接编译后无法访问饭否。用户需要自行去申请oauth key，并填入 Configuration.java 中。
 
-###功能：
+### 功能：
 发送/删除消息，发送/回复私信，回复/转发/收藏消息，关注用户，查看用户资料
 
-###特性：
+### 特性：
 拍照/图片上传，后台自动提醒，桌面Widget
 
 [下载安能饭否](https://github.com/fanfoudroid/fanfoudroid/fanfoudroid_0.7.5.5.apk/qr_code) / [Android Market安装](https://market.android.com/details?id=com.ch_linghu.fanfoudroid) / [报告BUG](https://github.com/fanfoudroid/fanfoudroid/issues) / [提出建议](https://github.com/fanfoudroid/fanfoudroid/pulls)
-##截图
+## 截图
 ![Screenshot](http://farm4.static.flickr.com/3292/5746245984_4d2edf87cb.jpg)
-##News
+## News
 `2012-02-20` : 安能饭否 v0.7.5.5 发布，增加转发支持。注意，本版本修改了数据模型，如遇FC错误，请卸载后重装。
 
 `2011-11-29` : 安能饭否 v0.7.5.4 发布，换用oauth认证。 
@@ -34,17 +34,17 @@
 
 `2011-04-28` : 安能饭否 v0.7.2 发布, 增加Widget功能。 
  
-##版本更新
-###v0.7.5.5 `2012-02-20`
+## 版本更新
+### v0.7.5.5 `2012-02-20`
 增加转发支持（显示转自**内容）
 
 
-###v0.7.5.3, `2011-09-06`
+### v0.7.5.3, `2011-09-06`
 
 修复一些FC的问题
 
 
-###0.7.5.2 `2011-09-04`
+### 0.7.5.2 `2011-09-04`
 * 修复部分用户自0.7.5更新后执行效率极低的问题（非常抱歉！）
 * 修复低分辨率用户写消息界面文字看不到的问题
 * 修复横竖屏切换后跳回列表开头的问题
@@ -53,19 +53,19 @@
 * 改善下拉列表用户体验
 * 其他bug修复
 
-####0.7.5 `2011-08-23`
+#### 0.7.5 `2011-08-23`
 * 新增 下拉刷新 功能
 * 新增 对自己的发言以及他人提到自己的发言高亮显示 功能
 * 改进 新的Logo图标
 * 改进 界面细节
 * 大量bug修复
 
-####0.7.4 `2011-08-07`
+#### 0.7.4 `2011-08-07`
 * 项目组新增成员 @忽然兔
 * 增加 4x1 widget
 * 增加 繁体中文界面
 * 增加 关于界面“反馈”功能
 * 细节调整和bug修复
 
-##联系开发者
+## 联系开发者
 [@令狐虫](http://fanfou.com/ch_linghu) / [@PhoenixG](http://fanfou.com/phoenixg) / [@dodola](http://fanfou.com/%E8%90%BD%E5%A6%96) [Gmail](mailto:dinophp@gmail.com) / [@三日坊主](http://fanfou.com/lds2012) / [@忽然兔](http://fanfou.com/zm1103)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
